### PR TITLE
Simplified lisp-unit Interface

### DIFF
--- a/tests.lisp
+++ b/tests.lisp
@@ -23,7 +23,7 @@
 
 (in-package :hh-redblack-tests)
 
-(remove-all-tests)
+(remove-tests :all)
 
 (define-test create-rb-rtree-tests
     (let ((tree (make-red-black-tree)))
@@ -315,4 +315,4 @@
 		  (with-rb-transaction (tree)
 		    (rb-keys tree)))))
 
-(run-tests)
+(run-tests :all)


### PR DESCRIPTION
The interface to lisp-unit has been simplified. This pull will modify remove-all-tests and run-tests to conform to the simplified interface.
